### PR TITLE
improve error handling in merge_bytes_small

### DIFF
--- a/src/comms.rs
+++ b/src/comms.rs
@@ -44,19 +44,18 @@ impl Motor for VescCanMotor {
 }
 
 // Helpers
-fn merge_bytes_small(bytes: Vec<u8>) -> u32 {
+fn merge_bytes_small(bytes: Vec<u8>) -> Result<u32, String> {
     if bytes.len() > 4 {
-        // This should really be an error value instead of a panic, but I'm rushing things.
-        panic!("merge_bytes_small can only be called on series of bytes smaller than 4.");
+        return Err("merge_bytes_small can only be called on series of bytes smaller than 4");
     }
 
     let mut shift_val = 0;
     let mut out = 0_u32;
 
     for byte in bytes {
-        out |= (byte as u32) << shift_val; // Insert the next byte
-        shift_val += 8; // Make all future loops farther over
+        out |= (byte as u32) << shift_val;
+        shift_val += 8;
     }
 
-    out
+    Ok(out)
 }

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -53,7 +53,7 @@ impl Motor for VescCanMotor {
 // Helpers
 fn merge_bytes_small(bytes: Vec<u8>) -> Result<u32, String> {
     if bytes.len() > 4 {
-        return Err("merge_bytes_small can only be called on series of bytes smaller than 4");
+        return Err("merge_bytes_small can only be called on series of bytes smaller than 4".to_string());
     }
 
     let mut shift_val = 0;

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -35,11 +35,18 @@ impl Motor for VescCanMotor {
         // Create the message object
         let msg = Message::new(command, self.id, payload);
 
-        let id = ExtendedId::new(merge_bytes_small(msg.to_header_binary())).unwrap();
-        // Turn it into socketcan's message object
-        let frame: CanFrame = CanFrame::new(id, msg.to_body_binary().as_slice()).unwrap();
-        // Send it
-        _ = self.soc.write_frame_insist(&frame);
+        match merge_bytes_small(message.to_header_binary()) {
+            Ok(id) => {
+                let id = ExtendedId::new(id).unwrap();
+                // Turn it into socketcan's message object
+                let frame: canFrame = canFrame::new(id, msg.to_body_binary().as_slice()).unwrap();
+                // Send it
+                _ = self.soc.write_frame_insist(&frame);
+            }
+            Err(e) => {
+                panic!("error merging bytes: {}", e);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Previously, the merge_bytes_small function would panic if the input byte slice was larger than 4 bytes. This could lead to unexpected program termination. This pull request replaces the panic! with a Result return type, allowing for more graceful error handling.